### PR TITLE
fix: resolve pnpm interactive build approval in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN corepack enable
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml .npmrc ./
-RUN pnpm install --config.enable-pre-post-scripts=true --ignore-scripts=false
-RUN pnpm approve-builds
+RUN pnpm install --config.enable-pre-post-scripts=true --ignore-scripts=false --allow-scripts
 RUN pnpm install --config.enable-pre-post-scripts=true
 COPY . .
 RUN pnpm run build


### PR DESCRIPTION
## 🐛 Problem
Docker build was failing with `[ERR_PNPM_IGNORED_BUILDS]` error when trying to run `pnpm approve-builds`, which is an interactive command that doesn't work in non-interactive CI/CD environments like Jenkins.

**Error:**
```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.4, sharp@0.34.5
ERROR: process "/bin/sh -c pnpm install..." did not complete successfully: exit code: 1
```

## ✅ Solution
- **Removed** the interactive `pnpm approve-builds` command from the Dockerfile
- **Added** `--allow-scripts` flag to the first pnpm install command to automatically approve build scripts

This allows pnpm to execute build scripts (esbuild, sharp) without requiring interactive approval, making it compatible with CI/CD pipelines and Docker builds.

## 📝 Changes
- Modified `Dockerfile` (1 insertion, 2 deletions)
  - Removed line 9: `RUN pnpm approve-builds`
  - Updated line 8: Added `--allow-scripts` flag to `pnpm install`

## 🧪 Testing
Jenkins pipeline should now successfully build the Docker image without the pnpm build approval error.